### PR TITLE
Allow override of dlls with WINEDLLOVERRIDES environment variable

### DIFF
--- a/proton.in
+++ b/proton.in
@@ -332,7 +332,10 @@ for dll in dlloverrides:
         s = s + ";" + dll + "=" + setting
     else:
         s = dll + "=" + setting
-env["WINEDLLOVERRIDES"] = s
+if len(env["WINEDLLOVERRIDES"]) > 0:
+    env["WINEDLLOVERRIDES"] = env["WINEDLLOVERRIDES"] + ';' + s
+else:
+    env["WINEDLLOVERRIDES"] = s
 
 ARCH_UNKNOWN=0
 ARCH_I386=1


### PR DESCRIPTION
Proton overrides the environment variable WINEDLLOVERRIDES entirely, this change allows to add own dll overrides.